### PR TITLE
Use native markdown for equation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ Hardware description languages(HDL) are not meant to be for rapid prototyping. T
 
 Sum of Absolute difference and Sum of Squared Difference Disparity calculation theory is based on a simple geometric concept. Where they use the stereo vision to calculate the distance to the objects. For the implementation, two cameras should be on the same plane and they should not have any vertical offsets in their alignments.
 
-
-
-<a  href="https://www.codecogs.com/eqnedit.php?latex=D(x,y,d)&space;=&space;|I_l(x,y)-I_r(x-d,y)|^2" target="_blank"><img align="center" src="https://latex.codecogs.com/gif.latex?D(x,y,d)&space;=&space;|I_l(x,y)-I_r(x-d,y)|^2" title="Sum of Squred difference" /></a>
+$D(x,y,d) = |I_l(x,y)-I_r(x-d,y)|^2$
 
 **Python implementation**
 


### PR DESCRIPTION
GitHub has recently implimented native support for equations in markdown using the '$' characters. See: https://github.blog/2022-05-19-math-support-in-markdown/
This commit updates the SAD/SSD equation to use this new feature.